### PR TITLE
fix topology stream-key-join-key-join-to

### DIFF
--- a/KafkaStreams/Models/Job.cs
+++ b/KafkaStreams/Models/Job.cs
@@ -1,7 +1,10 @@
-﻿namespace KafkaStreams.Models;
+﻿using System;
 
-public class Job
+namespace KafkaStreams.Models
 {
-    public string Id { get; set; } = Guid.NewGuid().ToString();
-    public string Company { get; set; }
+    public class Job
+    {
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+        public string Company { get; set; }
+    }
 }

--- a/KafkaStreams/Models/Location.cs
+++ b/KafkaStreams/Models/Location.cs
@@ -1,7 +1,10 @@
-﻿namespace KafkaStreams.Models;
+﻿using System;
 
-public class Location
+namespace KafkaStreams.Models
 {
-    public string Id { get; set; } = Guid.NewGuid().ToString();
-    public string City { get; set; }
+    public class Location
+    {
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+        public string City { get; set; }
+    }
 }

--- a/KafkaStreams/Models/Person.cs
+++ b/KafkaStreams/Models/Person.cs
@@ -1,10 +1,13 @@
-﻿namespace KafkaStreams.Models;
+﻿using System;
 
-public class Person
+namespace KafkaStreams.Models
 {
-    public string Id { get; set; } = Guid.NewGuid().ToString();
-    public string Name { get; set; }
-    public string Surname { get; set; }
-    public string LocationId { get; set; }
-    public string JobId { get; set; }
+    public class Person
+    {
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+        public string Name { get; set; }
+        public string Surname { get; set; }
+        public string LocationId { get; set; }
+        public string JobId { get; set; }
+    }
 }

--- a/KafkaStreams/Models/PersonJobLocation.cs
+++ b/KafkaStreams/Models/PersonJobLocation.cs
@@ -1,8 +1,9 @@
-﻿namespace KafkaStreams.Models;
-
-public class PersonJobLocation
+﻿namespace KafkaStreams.Models
 {
-    public Person Person { get; set; }
-    public Job Job { get; set; }
-    public Location Location { get; set; }
+    public class PersonJobLocation
+    {
+        public Person Person { get; set; }
+        public Job Job { get; set; }
+        public Location Location { get; set; }
+    }
 }

--- a/KafkaStreams/Models/PersonLocation.cs
+++ b/KafkaStreams/Models/PersonLocation.cs
@@ -1,7 +1,8 @@
-﻿namespace KafkaStreams.Models;
-
-public class PersonLocation
+﻿namespace KafkaStreams.Models
 {
-    public Person Person { get; set; }
-    public Location Location { get; set; }
+    public class PersonLocation
+    {
+        public Person Person { get; set; }
+        public Location Location { get; set; }
+    }
 }

--- a/KafkaStreams/Program.cs
+++ b/KafkaStreams/Program.cs
@@ -1,34 +1,45 @@
+using System;
+using System.Threading;
 using Confluent.Kafka;
 using KafkaStreams.Models;
 using KafkaStreams.Serializers;
+using KafkaStreams.Services;
 using Streamiz.Kafka.Net;
 using Streamiz.Kafka.Net.SerDes;
+using Streamiz.Kafka.Net.Stream;
+using Streamiz.Kafka.Net.Table;
 
-// await new Migrator().Execute(CancellationToken.None);
+await new Migrator().Execute(CancellationToken.None, "persons", "locations", "jobs");
 
-var config = new StreamConfig<StringSerDes, JsonSerDes>
+var config = new StreamConfig<StringSerDes, StringSerDes>
 {
     ApplicationId = "test-app",
     BootstrapServers = "localhost:9093",
-    AutoOffsetReset = AutoOffsetReset.Earliest,
+    AutoOffsetReset = AutoOffsetReset.Earliest
 };
 
 var builder = new StreamBuilder();
 
-var personStream = builder.Stream<string, Person>("persons", new StringSerDes(), new JsonSerDes<Person>());
-var locationStream = builder.Stream<string, Location>("locations", new StringSerDes(), new JsonSerDes<Location>());
-var jobStream = builder.Stream<string, Job>("jobs", new StringSerDes(), new JsonSerDes<Job>());
+var stringSerdes = new StringSerDes();
+var personSerdes = new JsonSerDes<Person>();
+var locationSerdes = new JsonSerDes<Location>();
+var jobSerdes = new JsonSerDes<Job>();
+
+var personStream = builder.Stream<string, Person>("persons", stringSerdes, personSerdes);
+var locationStream = builder.Stream<string, Location>("locations", stringSerdes, locationSerdes);
+var jobStream = builder.Stream<string, Job>("jobs", stringSerdes, jobSerdes);
 
 personStream
     .SelectKey((_, v) => v.LocationId)
-    .Join(locationStream.ToTable(),
-        (v1, v2) => new PersonLocation
-        {
+    .Join(locationStream.ToTable(RocksDb<string, Location>.Create().WithKeySerdes(stringSerdes).WithValueSerdes(locationSerdes)), // you have to specify the good serdes for materialize your state store inside the changelog topic
+        (v1, v2) => new PersonLocation {
             Person = v1,
             Location = v2
         })
-    .SelectKey((_, v) => v.Person.JobId)
-    .Join(jobStream.ToTable(), (v1, v2) => new PersonJobLocation{
+    .SelectKey((_, v) => v.Person.JobId) // here you change the key and just after you make a statefull operation (eg/ join table job), a repartition topic will be create. Key : string, Value : PersonLocation. Issue : you can't specify the value serdes for PersonLocation in join operation just before. Workaround : create a repartition topic manually
+    .Repartition(Repartitioned<string,PersonLocation>.Create<StringSerDes, JsonSerDes<PersonLocation>>()) // workaround because for now, you can't specify the serdes for VR in join operation
+    .Join(jobStream.ToTable(RocksDb<string, Job>.Create().WithKeySerdes(stringSerdes).WithValueSerdes(jobSerdes)), // you have to specify the good serdes for materialize your state store inside the changelog topic
+        (v1, v2) => new PersonJobLocation {
         Person = v1.Person,
         Location = v1.Location,
         Job = v2

--- a/KafkaStreams/Serializers/JsonSerDes.cs
+++ b/KafkaStreams/Serializers/JsonSerDes.cs
@@ -3,53 +3,19 @@ using Confluent.Kafka;
 using Newtonsoft.Json;
 using Streamiz.Kafka.Net.SerDes;
 
-namespace KafkaStreams.Serializers;
-
-public class JsonSerDes : ISerDes
+namespace KafkaStreams.Serializers
 {
-    public object DeserializeObject(byte[] data, SerializationContext context)
-    {
-        return JsonConvert.DeserializeObject(Encoding.UTF8.GetString(data));
-    }
 
-    public byte[] SerializeObject(object data, SerializationContext context)
+    public class JsonSerDes<T> : AbstractSerDes<T>
     {
-        return Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(data));
-    }
+        public override T Deserialize(byte[] data, SerializationContext context)
+        {
+            return JsonConvert.DeserializeObject<T>(Encoding.UTF8.GetString(data));
+        }
 
-    public void Initialize(SerDesContext context)
-    {
-    }
-}
-
-public class JsonSerDes<T> : ISerDes<T>
-{
-    public void Initialize(SerDesContext context)
-    {
-    }
-    
-    public object DeserializeObject(byte[] data, SerializationContext context)
-    {
-        return JsonConvert.DeserializeObject(Encoding.UTF8.GetString(data));
-    }
-
-    public byte[] SerializeObject(object data, SerializationContext context)
-    {
-        return Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(data));
-    }
-
-    public T Deserialize(byte[] data, SerializationContext context)
-    {
-        return JsonConvert.DeserializeObject<T>(Encoding.UTF8.GetString(data));
-    }
-
-    public byte[] Serialize(string data, SerializationContext context)
-    {
-        throw new NotImplementedException();
-    }
-
-    public byte[] Serialize(T data, SerializationContext context)
-    {
-        return Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(data));
+        public override byte[] Serialize(T data, SerializationContext context)
+        {
+            return Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(data));
+        }
     }
 }

--- a/KafkaStreams/Serializers/JsonSerializer.cs
+++ b/KafkaStreams/Serializers/JsonSerializer.cs
@@ -1,18 +1,21 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
 using Confluent.Kafka;
 using Newtonsoft.Json;
 
-namespace KafkaStreams.Serializers;
-
-public class JsonSerializer<T> : ISerializer<T>, IDeserializer<T>
+namespace KafkaStreams.Serializers
 {
-    public byte[] Serialize(T data, SerializationContext context)
-    {
-        return Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(data));
-    }
 
-    public T Deserialize(ReadOnlySpan<byte> data, bool isNull, SerializationContext context)
+    public class JsonSerializer<T> : ISerializer<T>, IDeserializer<T>
     {
-        return JsonConvert.DeserializeObject<T>(Encoding.UTF8.GetString(data));
+        public byte[] Serialize(T data, SerializationContext context)
+        {
+            return Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(data));
+        }
+
+        public T Deserialize(ReadOnlySpan<byte> data, bool isNull, SerializationContext context)
+        {
+            return JsonConvert.DeserializeObject<T>(Encoding.UTF8.GetString(data));
+        }
     }
 }

--- a/KafkaStreams/Services/Migrator.cs
+++ b/KafkaStreams/Services/Migrator.cs
@@ -1,86 +1,124 @@
-﻿using Confluent.Kafka;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.Kafka;
 using KafkaStreams.Models;
 using KafkaStreams.Serializers;
 
-namespace KafkaStreams.Services;
-
-public class Migrator
+namespace KafkaStreams.Services
 {
-    public async Task Execute(CancellationToken cancellationToken)
+
+    public class Migrator
     {
-        var config = new ProducerConfig
+        public async Task Execute(CancellationToken cancellationToken, params string[] topicsToCreate)
         {
-            BootstrapServers = "localhost:9093"
-        };
+            var adminConfig = new AdminClientConfig()
+            {
+                BootstrapServers = "localhost:9093"
+            };
 
-        using var personProducer = new ProducerBuilder<string, Person>(config)
-            .SetValueSerializer(new JsonSerializer<Person>())
-            .Build();
-        using var locationProducer = new ProducerBuilder<string, Location>(config)
-            .SetValueSerializer(new JsonSerializer<Location>())
-            .Build();
-        using var jobProducer = new ProducerBuilder<string, Job>(config)
-            .SetValueSerializer(new JsonSerializer<Job>())
-            .Build();
+            using var adminClient = new AdminClientBuilder(adminConfig).Build();
 
-        var locations = new List<Location>
-        {
-            new() { Id = Guid.NewGuid().ToString(), City = "New York" },
-            new() { Id = Guid.NewGuid().ToString(), City = "London" },
-            new() { Id = Guid.NewGuid().ToString(), City = "Paris" },
-            new() { Id = Guid.NewGuid().ToString(), City = "Berlin" },
-        };
-        var jobs = new List<Job>
-        {
-            new(){ Id = Guid.NewGuid().ToString(), Company = "Google"},
-            new(){ Id = Guid.NewGuid().ToString(), Company = "Microsoft"},
-            new(){ Id = Guid.NewGuid().ToString(), Company = "Apple"},
-            new(){ Id = Guid.NewGuid().ToString(), Company = "Facebook"},
-            new(){ Id = Guid.NewGuid().ToString(), Company = "Amazon"},
-        };
-        
-        var people = new List<Person>
-        {
-            new() { Id = Guid.NewGuid().ToString(), Name = "John", LocationId = locations[0].Id, JobId = jobs[0].Id },
-            new() { Id = Guid.NewGuid().ToString(), Name = "Jane", LocationId = locations[1].Id, JobId = jobs[1].Id  },
-            new() { Id = Guid.NewGuid().ToString(), Name = "Jack", LocationId = locations[2].Id, JobId = jobs[2].Id  },
-            new() { Id = Guid.NewGuid().ToString(), Name = "Jill", LocationId = locations[3].Id, JobId = jobs[3].Id  },
-        };
+            try
+            {
+                // create topic, catch exception and do nothing if topics are already exist. just for dev environment
+                await adminClient.CreateTopicsAsync(
+                    topicsToCreate.Select(t => new Confluent.Kafka.Admin.TopicSpecification
+                    {
+                        Name = t,
+                        NumPartitions = 3
+                    }));
+            }
+            catch
+            {
+                // nothing if topic already exist
+            }
 
-        foreach (var location in locations)
-        {
-            await locationProducer.ProduceAsync(
-                "locations",
-                new Message<string, Location>
-                {
-                    Key = location.Id,
-                    Value = location
-                },
-                cancellationToken);
-        }
+            var config = new ProducerConfig
+            {
+                BootstrapServers = "localhost:9093"
+            };
 
-        foreach (var job in jobs)
-        {
-            await jobProducer.ProduceAsync(
-                "jobs",
-                new Message<string, Job>
-                {
-                    Key = job.Id,
-                    Value = job
-                },
-                cancellationToken);
-        }
-        
-        foreach (var person in people)
-        {
-            await personProducer.ProduceAsync(
-                "persons",
-                new Message<string, Person>
-                {
-                    Key = person.Id,
-                    Value = person
-                },
-                cancellationToken);
+            using var personProducer = new ProducerBuilder<string, Person>(config)
+                .SetValueSerializer(new JsonSerializer<Person>())
+                .Build();
+            using var locationProducer = new ProducerBuilder<string, Location>(config)
+                .SetValueSerializer(new JsonSerializer<Location>())
+                .Build();
+            using var jobProducer = new ProducerBuilder<string, Job>(config)
+                .SetValueSerializer(new JsonSerializer<Job>())
+                .Build();
+
+            var locations = new List<Location>
+            {
+                new() {Id = Guid.NewGuid().ToString(), City = "New York"},
+                new() {Id = Guid.NewGuid().ToString(), City = "London"},
+                new() {Id = Guid.NewGuid().ToString(), City = "Paris"},
+                new() {Id = Guid.NewGuid().ToString(), City = "Berlin"},
+            };
+            var jobs = new List<Job>
+            {
+                new() {Id = Guid.NewGuid().ToString(), Company = "Google"},
+                new() {Id = Guid.NewGuid().ToString(), Company = "Microsoft"},
+                new() {Id = Guid.NewGuid().ToString(), Company = "Apple"},
+                new() {Id = Guid.NewGuid().ToString(), Company = "Facebook"},
+                new() {Id = Guid.NewGuid().ToString(), Company = "Amazon"},
+            };
+
+            var people = new List<Person>
+            {
+                new() {Id = Guid.NewGuid().ToString(), Name = "John", LocationId = locations[0].Id, JobId = jobs[0].Id},
+                new() {Id = Guid.NewGuid().ToString(), Name = "Jane", LocationId = locations[1].Id, JobId = jobs[1].Id},
+                new() {Id = Guid.NewGuid().ToString(), Name = "Jack", LocationId = locations[2].Id, JobId = jobs[2].Id},
+                new() {Id = Guid.NewGuid().ToString(), Name = "Jill", LocationId = locations[3].Id, JobId = jobs[3].Id},
+            };
+
+            foreach (var location in locations)
+            {
+                await locationProducer.ProduceAsync(
+                    "locations",
+                    new Message<string, Location>
+                    {
+                        Key = location.Id,
+                        Value = location
+                    },
+                    cancellationToken);
+            }
+
+            // flush in the location producer. Wait all messages are persisted into the broker
+            locationProducer.Flush(cancellationToken);
+
+            foreach (var job in jobs)
+            {
+                await jobProducer.ProduceAsync(
+                    "jobs",
+                    new Message<string, Job>
+                    {
+                        Key = job.Id,
+                        Value = job
+                    },
+                    cancellationToken);
+            }
+
+            // flush in the job producer. Wait all messages are persisted into the broker
+            jobProducer.Flush(cancellationToken);
+
+            foreach (var person in people)
+            {
+                await personProducer.ProduceAsync(
+                    "persons",
+                    new Message<string, Person>
+                    {
+                        Key = person.Id,
+                        Value = person
+                    },
+                    cancellationToken);
+            }
+
+            // flush in the person producer. Wait all messages are persisted into the broker
+            personProducer.Flush(cancellationToken);
         }
     }
 }


### PR DESCRIPTION
- I add some comments in my code
- I will create a ticket in my repository to allow passing new value serdes (VRS) in join operation

Advices :
- Keep in mind, that all state stores is back by a kafka changelog topic. And if key/value serdes is not defined. Streamiz will try to take the default one. But if it's not the same type, you can't
- Keep in mind 2, if you change the key (selectKey, map, flatMap, groupByKey) and after you do a statefull operation (agg, reduce, join, leftJoin...) a kafka repartition topic will be created to materialize the key's change. Same for point 1, you need correct serdes (for key / value repartition records). Unfortunately, when you join you can pass Value0 Serdes but not ValueR Serdes for now. 


I will fix that ASAP.